### PR TITLE
Changes to malloc() for sanity checking...

### DIFF
--- a/freebsd_tests64/InjectSharedObject.c
+++ b/freebsd_tests64/InjectSharedObject.c
@@ -45,6 +45,13 @@ int main(int argc, char *argv[])
 	}
 	backup = GetRegs(hijack);
 	regs = malloc(sizeof(REGS));
+	if (regs == NULL)
+	{
+		perror("malloc");
+		Detach(hijack);
+		close(fd);
+		exit(EXIT_FAILURE);
+	}
 	
 	if (stat(argv[2], &sb) == -1) {
         perror("stat");


### PR DESCRIPTION
Patch adds sanity check for malloc in InjectSharedObject.c in
FreeBSD_tests64
